### PR TITLE
Add dependency to sbt-pgp plugins

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,9 +34,3 @@ lazy val plugin = project
     addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")
   )
 
-// For some reason, it doesn't work if this is defined in buildSettings in CiReleasePlugin.
-inScope(Global)(
-  Seq(
-    PgpKeys.pgpPassphrase := sys.env.get("PGP_PASSPHRASE").map(_.toCharArray())
-  )
-)

--- a/build.sbt
+++ b/build.sbt
@@ -33,4 +33,3 @@ lazy val plugin = project
     addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.3"),
     addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")
   )
-

--- a/plugin/src/main/scala/com/geirsson/CiReleasePlugin.scala
+++ b/plugin/src/main/scala/com/geirsson/CiReleasePlugin.scala
@@ -25,7 +25,7 @@ object CiReleasePlugin extends AutoPlugin {
 
   override def buildSettings: Seq[Def.Setting[_]] = List(
     dynverSonatypeSnapshots := true,
-    pgpPassphrase := sys.env.get("PGP_PASSPHRASE").map(_.toCharArray()),
+    pgpPassphrase := sys.env.get("PGP_PASSPHRASE").map(_.toCharArray())
   )
 
   override def globalSettings: Seq[Def.Setting[_]] = List(

--- a/plugin/src/main/scala/com/geirsson/CiReleasePlugin.scala
+++ b/plugin/src/main/scala/com/geirsson/CiReleasePlugin.scala
@@ -1,6 +1,8 @@
 package com.geirsson
 
 import sbtdynver.DynVerPlugin.autoImport._
+import com.typesafe.sbt.SbtPgp
+import com.typesafe.sbt.SbtPgp.autoImport._
 import sbt.Def
 import sbt._
 import sbt.Keys._
@@ -10,7 +12,7 @@ import sys.process._
 object CiReleasePlugin extends AutoPlugin {
 
   override def trigger = allRequirements
-  override def requires = JvmPlugin
+  override def requires = JvmPlugin && SbtPgp
 
   def isTravisTag: Boolean =
     Option(System.getenv("TRAVIS_TAG")).exists(_.nonEmpty)
@@ -22,7 +24,8 @@ object CiReleasePlugin extends AutoPlugin {
   }
 
   override def buildSettings: Seq[Def.Setting[_]] = List(
-    dynverSonatypeSnapshots := true
+    dynverSonatypeSnapshots := true,
+    pgpPassphrase := sys.env.get("PGP_PASSPHRASE").map(_.toCharArray()),
   )
 
   override def globalSettings: Seq[Def.Setting[_]] = List(

--- a/readme.md
+++ b/readme.md
@@ -61,14 +61,6 @@ inThisBuild(List(
 ))
 ```
 
-Next, copy-paste the following to the bottom of `build.sbt`
-
-```scala
-inScope(Global)(List(
-  PgpKeys.pgpPassphrase := sys.env.get("PGP_PASSPHRASE").map(_.toCharArray())
-))
-```
-
 Next, create a fresh gpg key that you will share with Travis CI and only use for
 this project.
 


### PR DESCRIPTION
The dependency in `requires` was missing so this plugin `buildSettings` are applied after sbt-pgp ones.