### PR TITLE
Allow overwrite = true when publishing

### DIFF
--- a/plugin/src/main/scala/com/geirsson/CiReleasePlugin.scala
+++ b/plugin/src/main/scala/com/geirsson/CiReleasePlugin.scala
@@ -72,6 +72,10 @@ object CiReleasePlugin extends AutoPlugin {
   )
 
   override def projectSettings: Seq[Def.Setting[_]] = List(
+    publishConfiguration :=
+      publishConfiguration.value.withOverwrite(true),
+    publishLocalConfiguration :=
+      publishLocalConfiguration.value.withOverwrite(true),
     publishTo := sonatypePublishTo.value
   )
 


### PR DESCRIPTION
I've encountered several times that release fails because of the same
module being published twice. The recommended solution is to "fix the
release step" to avoid duplicate publishing. However, in my case it's
happening for a Java-only module with CrossVersion.disabled and
crossScalaVersions 2.12 and still it tries to publish for 2.11 and 2.12,
causing overwrite = false errors.

I've manually tested this change in Scalafix and it resolved the issue I
was facing with the Java-only module.