### PR TITLE
Add customizable sonatypeRelease step

### DIFF
--- a/plugin/src/main/scala/com/geirsson/CiReleasePlugin.scala
+++ b/plugin/src/main/scala/com/geirsson/CiReleasePlugin.scala
@@ -89,7 +89,7 @@ object CiReleasePlugin extends AutoPlugin {
         } else {
           println("Tag push detected, publishing a stable release")
           sys.env.getOrElse("CI_RELEASE", "+publishSigned") ::
-            s"sonatypeRelease" ::
+            sys.env.getOrElse("CI_SONATYPE_RELEASE", "sonatypeRelease") ::
             currentState
         }
       }

--- a/readme.md
+++ b/readme.md
@@ -176,6 +176,7 @@ gpg --armor --export-secret-keys $LONG_ID | base64 | xclip
   releases. Defaults to `+publishSigned` if not provided.
 - (optional) `CI_SNAPSHOT_RELEASE`: the command to publish all artifacts for a
   SNAPSHOT releases. Defaults to `+publish` if not provided.
+- (optional) `CI_SONATYPE_RELEASE`: the command called to close and promote the staged repository. Useful when, for example, also dealing with non-sbt projects to change to `sonatypeReleaseAll`. Defaults to `sonatypeRelease` if not provided.
 
 ### .travis.yml
 


### PR DESCRIPTION
I have the following setup:

- An sbt project
- A maven project inside the same repo

I want to have the maven project included in the `sbt-ci-release` workflow. In order to only fully release once all projects are built and staged, I want to use the `sonatypeReleaseAll` step that sbt-sonatype provides. This PR lets you customize the command with an environment variable.

I'm also open to suggestions about any clearer name for the env variable.