### PR TITLE
Use sbt-sonatype bundle release to speed up publishing

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,6 +26,6 @@ lazy val plugin = project
     sbtPlugin := true,
     addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.0.0"),
     addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0"),
-    addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.6"),
+    addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.4"),
     addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.2")
   )

--- a/plugin/src/main/scala/com/geirsson/CiReleasePlugin.scala
+++ b/plugin/src/main/scala/com/geirsson/CiReleasePlugin.scala
@@ -89,7 +89,7 @@ object CiReleasePlugin extends AutoPlugin {
         } else {
           println("Tag push detected, publishing a stable release")
           sys.env.getOrElse("CI_RELEASE", "+publishSigned") ::
-            sys.env.getOrElse("CI_SONATYPE_RELEASE", "sonatypeRelease") ::
+            sys.env.getOrElse("CI_SONATYPE_RELEASE", "sonatypeBundleRelease") ::
             currentState
         }
       }
@@ -101,7 +101,7 @@ object CiReleasePlugin extends AutoPlugin {
       publishConfiguration.value.withOverwrite(true),
     publishLocalConfiguration :=
       publishLocalConfiguration.value.withOverwrite(true),
-    publishTo := sonatypePublishTo.value
+    publishTo := sonatypePublishToBundle.value
   )
 
   def isSnapshotVersion(state: State): Boolean = {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,7 +8,7 @@ addSbtPlugin(
   "io.get-coursier" % "sbt-shading" % coursier.util.Properties.version
 )
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.0.0")
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.6")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.4")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.2")
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")
 libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value


### PR DESCRIPTION
This resolves #58 in principle but despite changing the sbt-sonatype version to 3.4 `libraryDependencies` still shows 2.6 and the `sonatypePublishToBundle` key is not found. I am completely baffled. Any ideas?

Also unclear how to test this.