### PR TITLE
Fix workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v1
     - uses: olafurpg/setup-scala@v10

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   update_release_draft:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: release-drafter/release-drafter@v5
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,9 +5,11 @@ on:
     tags: ["*"]
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2.3.3
+      - uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 0
       - uses: olafurpg/setup-scala@v10
       - uses: olafurpg/setup-gpg@v3
       - run: sbt ci-release


### PR DESCRIPTION
When I publish the snapshot version after the merge to master, the previous version from the tag is ignored and version 0.0.0 is used: `lib_2.13-0.0.0+1-b34f036b-SNAPSHOT`.

I figure out that `actions/checkout@v2` was changed and now fetch only the last commit without tags.
BTW I think that fixed dependency versions in CI/CD are better than "latest" because of fewer surprises.