### PR TITLE
Add gpg 2 support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,12 +21,12 @@ onLoadMessage := s"Welcome to sbt-ci-release ${version.value}"
 skip in publish := true // don't publish the root project
 
 lazy val plugin = project
+  .enablePlugins(SbtPlugin)
   .settings(
     moduleName := "sbt-ci-release",
-    sbtPlugin := true,
     sbtVersion in pluginCrossBuild := "1.0.4",
     addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1"),
     addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0"),
     addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.5"),
-    addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")
+    addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.1.1")
   )


### PR DESCRIPTION
Fixes #95
Ref https://github.com/sbt/sbt-pgp/pull/184
Ref https://dev.gnupg.org/T2313

This parses the gpg version number and uses `--batch --import` to import the secret key.

This should fix the mysterious error message we see on GitHub Actions:
```
error sending to agent: Inappropriate ioctl for device
```

I have not tested this, but I have a similar workaround as Bash script (https://github.com/sbt/sbt-projectmatrix/blob/7781c86aea159c90bd55d549eede41c65cb4e140/.github/decodekey.sh), which is able to auto publish using sbt-ci-release without downgrading to gpg 1.4.